### PR TITLE
Bugfix: Change condition to give True when splits - l is 0 to give correct P_k score

### DIFF
--- a/tools.py
+++ b/tools.py
@@ -44,7 +44,7 @@ def P_k(splits_ref, splits_hyp, N):
     hyp = np.array(splits_hyp, dtype=np.int32)
 
     def is_split_between(splits, l, r):
-        return np.sometrue(np.logical_and(splits - l > 0, splits - r < 0))
+        return np.sometrue(np.logical_and(splits - l >= 0, splits - r < 0))
 
     acc = 0
     for i in range(N-k):


### PR DESCRIPTION
Refer to https://github.com/chschock/textsplit/issues/4

This fixes the abovementioned bug when invoking the P_k function to calculate score.